### PR TITLE
L'Ajout de l'affichage RAM Used dans MemoryMonitor

### DIFF
--- a/include/MemoryMonitor.h
+++ b/include/MemoryMonitor.h
@@ -1,0 +1,16 @@
+#ifndef MEMORY_MONITOR_H
+#define MEMORY_MONITOR_H
+
+#include <string>
+
+class MemoryMonitor {
+    private:
+        long totalMemory;       // En kilooctets
+        long availableMemory;   // En kilooctets
+
+    public:
+        void update();               
+        std::string getUsageInfo();  
+};
+
+#endif

--- a/src/MemoryMonitor.cpp
+++ b/src/MemoryMonitor.cpp
@@ -1,0 +1,44 @@
+#include "MemoryMonitor.h"
+#include <fstream>      // Pour lire les fichiers
+#include <sstream>      // Pour analyser les lignes
+#include <iostream>
+#include <iomanip>      // Pour formater les nombres 
+using namespace std;
+
+void MemoryMonitor::update() {
+    ifstream file("/proc/meminfo");
+    string line;
+    totalMemory = 0;
+    availableMemory = 0;
+
+    while (getline(file, line)) {  //Boucle qui lit le fichier ligne par ligne
+        istringstream iss(line);
+        string key;
+        long value;
+        string unit;
+
+        iss >> key >> value >> unit;
+
+        if (key == "MemTotal:") {
+            totalMemory = value;  
+        } else if (key == "MemAvailable:") {
+            availableMemory = value;  
+        }
+
+        if (totalMemory > 0 && availableMemory > 0)
+            break;
+    }
+}
+
+string MemoryMonitor::getUsageInfo() {
+    long usedMemory = totalMemory - availableMemory;
+
+    double usedGB = usedMemory / 1024.0 / 1024.0;
+    double totalGB = totalMemory / 1024.0 / 1024.0;
+
+    ostringstream output;
+    output << fixed << setprecision(1);  
+    output << "RAM Used: " << usedGB << " GB / " << totalGB << " GB";
+
+    return output.str();
+}


### PR DESCRIPTION
J'ai implémenté la fonctionnalité demandée qui permet d'afficher en temps réel l'utilisation de la mémoire RAM dans l'interface en ligne de commande.
Les données sont récupérées depuis le fichier /proc/meminfo, puis converties et affichées au format lisible