### PR TITLE
Add basic CpuMonitor class structure with getCpuUsage() method

### DIFF
--- a/include/CpuMonitor.h
+++ b/include/CpuMonitor.h
@@ -1,0 +1,7 @@
+class CpuMonitor {
+    public:
+        CpuMonitor();                // Constructor
+        float getCpuUsage();        // Méthode qui va retourner l'utilisation du CPU
+    
+    };
+    

--- a/include/CpuMonitor.h
+++ b/include/CpuMonitor.h
@@ -1,7 +1,10 @@
+#ifndef CPUMONITOR_H
+#define CPUMONITOR_H
+
 class CpuMonitor {
-    public:
-        CpuMonitor();                // Constructor
-        float getCpuUsage();        // Méthode qui va retourner l'utilisation du CPU
-    
-    };
-    
+public:
+    CpuMonitor();                // Constructor
+    float getCpuUsage();         // Méthode qui va retourner l'utilisation du CPU
+};
+
+#endif // CPUMONITOR_H

--- a/src/CpuMonitor.cpp
+++ b/src/CpuMonitor.cpp
@@ -1,7 +1,13 @@
+#include "CpuMonitor.h"   
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <unistd.h>
+
 CpuMonitor::CpuMonitor() {
     // Constructor vide
 }
 
 float CpuMonitor::getCpuUsage() {
-    return 0.0f; 
+    return 0.0f; // Placeholder, pas encore de calcul
 }

--- a/src/CpuMonitor.cpp
+++ b/src/CpuMonitor.cpp
@@ -1,0 +1,7 @@
+CpuMonitor::CpuMonitor() {
+    // Constructor vide
+}
+
+float CpuMonitor::getCpuUsage() {
+    return 0.0f; 
+}


### PR DESCRIPTION
Updated CpuMonitor.h and CpuMonitor.cpp to include the initial structure of the CpuMonitor class.
Defined a public method getCpuUsage() as a placeholder for future CPU usage logic.