### PR TITLE
Implémentation de la lecture de /proc/stat et calcul de l’utilisation CPU en %

### DIFF
--- a/include/CpuMonitor.h
+++ b/include/CpuMonitor.h
@@ -1,0 +1,21 @@
+#ifndef CPUMONITOR_H
+#define CPUMONITOR_H
+
+#include <vector>
+#include <string>
+
+class CpuMonitor {
+public:
+    CpuMonitor();
+
+    bool readCpuStats(std::vector<unsigned long long>& stats);
+
+
+    double getCpuUsage();
+
+private:
+    std::vector<unsigned long long> prevStats;
+    bool firstRead;
+};
+
+#endif

--- a/include/CpuMonitor.h
+++ b/include/CpuMonitor.h
@@ -1,21 +1,33 @@
 #ifndef CPUMONITOR_H
 #define CPUMONITOR_H
 
-#include <vector>
 #include <string>
+#include <vector>
+
+struct CPU {
+    float usagePerCPU;
+    float frequency;
+    float frequencyMax;
+};
 
 class CpuMonitor {
 public:
     CpuMonitor();
 
-    bool readCpuStats(std::vector<unsigned long long>& stats);
-
-
-    double getCpuUsage();
+    bool update();             // Met à jour les stats CPU
+    float getCpuUsage();       // Renvoie le pourcentage d'utilisation globale
+    float getCpuFreq();        // Renvoie la fréquence actuelle
+    std::string getCpuInfo();  // Renvoie une chaîne d'information détaillée
 
 private:
+    short nbrCPU;
+    std::vector<CPU> cpus;
     std::vector<unsigned long long> prevStats;
     bool firstRead;
+
+    bool readCpuStats(std::vector<unsigned long long>& stats);
+    float getFrequency();
+    float getMaxFrequency();
 };
 
-#endif
+#endif // CPUMONITOR_H

--- a/src/CpuMonitor.cpp
+++ b/src/CpuMonitor.cpp
@@ -1,0 +1,78 @@
+#include "CpuMonitor.h"
+#include <fstream>
+#include <sstream>
+#include <thread>
+#include <chrono>
+#include <iostream>
+
+CpuMonitor::CpuMonitor() : firstRead(true) {}
+
+bool CpuMonitor::readCpuStats(std::vector<unsigned long long>& stats) {
+    std::ifstream file("/proc/stat");
+    if (!file.is_open()) {
+        std::cerr << "Impossible d'ouvrir /proc/stat\n";
+        return false;
+    }
+
+    std::string line;
+    while (std::getline(file, line)) {
+        if (line.compare(0, 3, "cpu") == 0 && (line.size() == 3 || line[3] == ' ')) {
+            std::istringstream ss(line);
+            std::string cpuLabel;
+            ss >> cpuLabel;
+
+            unsigned long long value;
+            stats.clear();
+            while (ss >> value) {
+                stats.push_back(value);
+            }
+            return true;
+        }
+    }
+    return false;
+}
+
+double CpuMonitor::getCpuUsage() {
+    std::vector<unsigned long long> currentStats;
+
+    if (!readCpuStats(currentStats)) {
+        return -1.0;
+    }
+
+    if (firstRead) {
+        prevStats = currentStats;
+        firstRead = false;
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        if (!readCpuStats(currentStats)) {
+            return -1.0;
+        }
+    }
+
+
+    unsigned long long prevIdle = prevStats[3] + prevStats[4];
+    unsigned long long idle = currentStats[3] + currentStats[4];
+
+    unsigned long long prevNonIdle = 0;
+    unsigned long long nonIdle = 0;
+
+    for (size_t i = 0; i < prevStats.size(); ++i) {
+        if (i != 3 && i != 4) {
+            prevNonIdle += prevStats[i];
+            nonIdle += currentStats[i];
+        }
+    }
+
+    unsigned long long prevTotal = prevIdle + prevNonIdle;
+    unsigned long long total = idle + nonIdle;
+
+    unsigned long long totald = total - prevTotal;
+    unsigned long long idled = idle - prevIdle;
+
+    prevStats = currentStats;
+
+    if (totald == 0) return 0.0;
+
+    double cpuPercentage = (double)(totald - idled) / totald * 100.0;
+    return cpuPercentage;
+}

--- a/src/CpuMonitor.cpp
+++ b/src/CpuMonitor.cpp
@@ -4,8 +4,12 @@
 #include <thread>
 #include <chrono>
 #include <iostream>
+#include <iomanip>
 
-CpuMonitor::CpuMonitor() : firstRead(true) {}
+CpuMonitor::CpuMonitor() : firstRead(true) {
+    nbrCPU = std::thread::hardware_concurrency();
+    cpus.resize(nbrCPU);
+}
 
 bool CpuMonitor::readCpuStats(std::vector<unsigned long long>& stats) {
     std::ifstream file("/proc/stat");
@@ -16,13 +20,12 @@ bool CpuMonitor::readCpuStats(std::vector<unsigned long long>& stats) {
 
     std::string line;
     while (std::getline(file, line)) {
-        if (line.compare(0, 3, "cpu") == 0 && (line.size() == 3 || line[3] == ' ')) {
+        if (line.rfind("cpu ", 0) == 0) {
             std::istringstream ss(line);
-            std::string cpuLabel;
-            ss >> cpuLabel;
-
-            unsigned long long value;
+            std::string label;
+            ss >> label;
             stats.clear();
+            unsigned long long value;
             while (ss >> value) {
                 stats.push_back(value);
             }
@@ -32,29 +35,26 @@ bool CpuMonitor::readCpuStats(std::vector<unsigned long long>& stats) {
     return false;
 }
 
-double CpuMonitor::getCpuUsage() {
+bool CpuMonitor::update() {
     std::vector<unsigned long long> currentStats;
 
     if (!readCpuStats(currentStats)) {
-        return -1.0;
+        return false;
     }
 
     if (firstRead) {
         prevStats = currentStats;
         firstRead = false;
-
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
         if (!readCpuStats(currentStats)) {
-            return -1.0;
+            return false;
         }
     }
-
 
     unsigned long long prevIdle = prevStats[3] + prevStats[4];
     unsigned long long idle = currentStats[3] + currentStats[4];
 
-    unsigned long long prevNonIdle = 0;
-    unsigned long long nonIdle = 0;
+    unsigned long long prevNonIdle = 0, nonIdle = 0;
 
     for (size_t i = 0; i < prevStats.size(); ++i) {
         if (i != 3 && i != 4) {
@@ -71,8 +71,52 @@ double CpuMonitor::getCpuUsage() {
 
     prevStats = currentStats;
 
-    if (totald == 0) return 0.0;
+    cpus[0].usagePerCPU = (totald != 0) ? ((float)(totald - idled) / totald * 100.0f) : 0.0f;
+    cpus[0].frequency = getFrequency();
+    cpus[0].frequencyMax = getMaxFrequency();
 
-    double cpuPercentage = (double)(totald - idled) / totald * 100.0;
-    return cpuPercentage;
+    return true;
+}
+
+float CpuMonitor::getCpuUsage() {
+    return cpus[0].usagePerCPU;
+}
+
+float CpuMonitor::getCpuFreq() {
+    return cpus[0].frequency;
+}
+
+std::string CpuMonitor::getCpuInfo() {
+    std::ostringstream info;
+    info << std::fixed << std::setprecision(2);
+    info << "Nombre de cœurs : " << nbrCPU << "\n";
+    info << "Utilisation : " << getCpuUsage() << " %\n";
+    info << "Fréquence actuelle : " << getCpuFreq() << " MHz\n";
+    info << "Fréquence maximale : " << cpus[0].frequencyMax << " MHz\n";
+    return info.str();
+}
+
+float CpuMonitor::getFrequency() {
+    std::ifstream file("/proc/cpuinfo");
+    std::string line;
+    while (std::getline(file, line)) {
+        if (line.find("cpu MHz") != std::string::npos) {
+            std::istringstream ss(line);
+            std::string label;
+            float freq;
+            ss >> label >> label >> freq;
+            return freq;
+        }
+    }
+    return 0.0f;
+}
+
+float CpuMonitor::getMaxFrequency() {
+    std::ifstream file("/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq");
+    if (file.is_open()) {
+        int khz;
+        file >> khz;
+        return khz / 1000.0f;
+    }
+    return 0.0f;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,21 @@
+#include <iostream>
+#include "CpuMonitor.h"
+#include <thread>
+#include <chrono>
+
+int main() {
+    CpuMonitor monitor;
+
+    while (true) {
+        double usage = monitor.getCpuUsage();
+        if (usage < 0) {
+            std::cerr << "Erreur lecture CPU\n";
+            return 1;
+        }
+
+        std::cout << "Utilisation CPU : " << usage << " %" << std::endl;
+
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
+    return 0;
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,21 +1,21 @@
 #include <iostream>
-#include "CpuMonitor.h"
 #include <thread>
 #include <chrono>
+#include "CpuMonitor.h"
 
 int main() {
     CpuMonitor monitor;
 
     while (true) {
-        double usage = monitor.getCpuUsage();
-        if (usage < 0) {
-            std::cerr << "Erreur lecture CPU\n";
+        if (!monitor.update()) {
+            std::cerr << "Erreur mise à jour CPU\n";
             return 1;
         }
 
-        std::cout << "Utilisation CPU : " << usage << " %" << std::endl;
+        std::cout << monitor.getCpuInfo() << std::endl;
 
         std::this_thread::sleep_for(std::chrono::seconds(1));
     }
+
     return 0;
 }


### PR DESCRIPTION
Cette pull request implémente la lecture du fichier /proc/stat pour récupérer les temps CPU.
Le code lit deux fois les statistiques avec un délai défini, puis calcule la différence (delta) pour obtenir le pourcentage d’utilisation CPU.

Cette méthode permet d’afficher l’utilisation CPU en temps réel de manière précise.
Cela constitue la base pour la surveillance CPU dans SysMon-cpp.ion