### PR TITLE
 Implémentation complète de la classe MemoryMonitor : mise à jour, stats RAM & swap, export texte/CSV

### DIFF
--- a/include/MemoryMonitor.h
+++ b/include/MemoryMonitor.h
@@ -1,0 +1,99 @@
+#ifndef MEMORY_MONITOR_H
+#define MEMORY_MONITOR_H
+
+#include <string>
+#include <map>
+
+/**
+ * @class MemoryMonitor
+ * @brief Classe pour surveiller l'utilisation de la mémoire
+ */
+class MemoryMonitor {
+public:
+    /**
+     * @brief Constructeur
+     */
+    MemoryMonitor();
+
+    /**
+     * @brief Destructeur
+     */
+    ~MemoryMonitor();
+
+    /**
+     * @brief Met à jour les informations de mémoire
+     * @return true si la mise à jour a réussi, false sinon
+     */
+    bool update();
+
+    /**
+     * @brief Obtient la mémoire totale en kB
+     * @return Mémoire totale
+     */
+    unsigned long long getTotalMemory() const;
+
+    /**
+     * @brief Obtient la mémoire libre en kB
+     * @return Mémoire libre
+     */
+    unsigned long long getFreeMemory() const;
+
+    /**
+     * @brief Obtient la mémoire utilisée en kB
+     * @return Mémoire utilisée
+     */
+    unsigned long long getUsedMemory() const;
+
+    /**
+     * @brief Obtient le pourcentage d'utilisation de la mémoire
+     * @return Pourcentage d'utilisation (0-100)
+     */
+    double getMemoryUsagePercentage() const;
+
+    /**
+     * @brief Obtient la mémoire swap totale en kB
+     * @return Swap total
+     */
+    unsigned long long getTotalSwap() const;
+
+    /**
+     * @brief Obtient la mémoire swap libre en kB
+     * @return Swap libre
+     */
+    unsigned long long getFreeSwap() const;
+
+    /**
+     * @brief Obtient la mémoire swap utilisée en kB
+     * @return Swap utilisé
+     */
+    unsigned long long getUsedSwap() const;
+
+    /**
+     * @brief Obtient le pourcentage d'utilisation du swap
+     * @return Pourcentage d'utilisation (0-100)
+     */
+    double getSwapUsagePercentage() const;
+
+    /**
+     * @brief Exporte les données au format texte
+     * @return Chaîne formatée des données mémoire
+     */
+    std::string exportAsText() const;
+
+    /**
+     * @brief Exporte les données au format CSV
+     * @return Chaîne CSV des données mémoire
+     */
+    std::string exportAsCSV() const;
+
+private:
+    std::map<std::string, unsigned long long> memInfo;
+
+    /**
+     * @brief Lit les données mémoire depuis /proc/meminfo
+     * @return true si la lecture a réussi, false sinon
+     */
+    bool readMemInfo();
+};
+
+#endif // MEMORY_MONITOR_H

--- a/src/MemoryMonitor.cpp
+++ b/src/MemoryMonitor.cpp
@@ -1,0 +1,166 @@
+#include "../include/MemoryMonitor.h"
+#include <fstream>
+#include <sstream>
+#include <iostream>
+#include <iomanip>
+
+MemoryMonitor::MemoryMonitor() {
+    // Initialisation
+    update();
+}
+
+MemoryMonitor::~MemoryMonitor() {
+    // Nettoyage si nécessaire
+}
+
+bool MemoryMonitor::update() {
+    return readMemInfo();
+}
+
+unsigned long long MemoryMonitor::getTotalMemory() const {
+    auto it = memInfo.find("MemTotal");
+    if (it != memInfo.end()) {
+        return it->second;
+    }
+    return 0;
+}
+
+unsigned long long MemoryMonitor::getFreeMemory() const {
+    unsigned long long free = 0;
+    
+    // MemFree + Buffers + Cached
+    auto itFree = memInfo.find("MemFree");
+    if (itFree != memInfo.end()) {
+        free += itFree->second;
+    }
+    
+    auto itBuffers = memInfo.find("Buffers");
+    if (itBuffers != memInfo.end()) {
+        free += itBuffers->second;
+    }
+    
+    auto itCached = memInfo.find("Cached");
+    if (itCached != memInfo.end()) {
+        free += itCached->second;
+    }
+    
+    return free;
+}
+
+unsigned long long MemoryMonitor::getUsedMemory() const {
+    return getTotalMemory() - getFreeMemory();
+}
+
+double MemoryMonitor::getMemoryUsagePercentage() const {
+    unsigned long long total = getTotalMemory();
+    if (total == 0) {
+        return 0.0;
+    }
+    
+    return 100.0 * getUsedMemory() / total;
+}
+
+unsigned long long MemoryMonitor::getTotalSwap() const {
+    auto it = memInfo.find("SwapTotal");
+    if (it != memInfo.end()) {
+        return it->second;
+    }
+    return 0;
+}
+
+unsigned long long MemoryMonitor::getFreeSwap() const {
+    auto it = memInfo.find("SwapFree");
+    if (it != memInfo.end()) {
+        return it->second;
+    }
+    return 0;
+}
+
+unsigned long long MemoryMonitor::getUsedSwap() const {
+    return getTotalSwap() - getFreeSwap();
+}
+
+double MemoryMonitor::getSwapUsagePercentage() const {
+    unsigned long long total = getTotalSwap();
+    if (total == 0) {
+        return 0.0;
+    }
+    
+    return 100.0 * getUsedSwap() / total;
+}
+
+std::string MemoryMonitor::exportAsText() const {
+    std::ostringstream oss;
+    
+    // Convertir kB en MB pour l'affichage
+    const double KB_TO_MB = 1024.0;
+    
+    oss << "Memory Usage:\n";
+    oss << "  Total: " << std::fixed << std::setprecision(2) << getTotalMemory() / KB_TO_MB << " MB\n";
+    oss << "  Used: " << std::fixed << std::setprecision(2) << getUsedMemory() / KB_TO_MB << " MB (" 
+        << std::fixed << std::setprecision(2) << getMemoryUsagePercentage() << "%)\n";
+    oss << "  Free: " << std::fixed << std::setprecision(2) << getFreeMemory() / KB_TO_MB << " MB\n";
+    
+    oss << "Swap Usage:\n";
+    oss << "  Total: " << std::fixed << std::setprecision(2) << getTotalSwap() / KB_TO_MB << " MB\n";
+    oss << "  Used: " << std::fixed << std::setprecision(2) << getUsedSwap() / KB_TO_MB << " MB (" 
+        << std::fixed << std::setprecision(2) << getSwapUsagePercentage() << "%)\n";
+    oss << "  Free: " << std::fixed << std::setprecision(2) << getFreeSwap() / KB_TO_MB << " MB\n";
+    
+    return oss.str();
+}
+
+std::string MemoryMonitor::exportAsCSV() const {
+    std::ostringstream oss;
+    
+    // Convertir kB en MB pour l'affichage
+    const double KB_TO_MB = 1024.0;
+    
+    // En-tête
+    oss << "Type,Total(MB),Used(MB),Free(MB),Usage(%)\n";
+    
+    // Mémoire
+    oss << "Memory," 
+        << std::fixed << std::setprecision(2) << getTotalMemory() / KB_TO_MB << ","
+        << std::fixed << std::setprecision(2) << getUsedMemory() / KB_TO_MB << ","
+        << std::fixed << std::setprecision(2) << getFreeMemory() / KB_TO_MB << ","
+        << std::fixed << std::setprecision(2) << getMemoryUsagePercentage() << "\n";
+    
+    // Swap
+    oss << "Swap," 
+        << std::fixed << std::setprecision(2) << getTotalSwap() / KB_TO_MB << ","
+        << std::fixed << std::setprecision(2) << getUsedSwap() / KB_TO_MB << ","
+        << std::fixed << std::setprecision(2) << getFreeSwap() / KB_TO_MB << ","
+        << std::fixed << std::setprecision(2) << getSwapUsagePercentage() << "\n";
+    
+    return oss.str();
+}
+
+bool MemoryMonitor::readMemInfo() {
+    std::ifstream memFile("/proc/meminfo");
+    if (!memFile.is_open()) {
+        std::cerr << "Failed to open /proc/meminfo" << std::endl;
+        return false;
+    }
+    
+    std::string line;
+    while (std::getline(memFile, line)) {
+        std::istringstream iss(line);
+        std::string key;
+        unsigned long long value;
+        std::string unit;
+        
+        // Format: "MemTotal:        8167848 kB"
+        if (iss >> key >> value >> unit) {
+            // Supprimer le ":" à la fin de la clé
+            if (!key.empty() && key.back() == ':') {
+                key.pop_back();
+            }
+            
+            memInfo[key] = value;
+        }
+    }
+    
+    memFile.close();
+    return true;
+}


### PR DESCRIPTION
Cette pull request introduit l’implémentation complète de la classe MemoryMonitor, responsable de la surveillance de la mémoire système (RAM & swap).
Elle comprend :

 Lecture des données depuis /proc/meminfo

Calcul de :

la mémoire totale, utilisée et libre

la mémoire swap totale, utilisée et libre

les pourcentages d’utilisation

Méthode update() pour rafraîchir les données à chaque cycle

Export des statistiques au format texte lisible et CSV

