### PR TITLE
 Ajout du module MemoryMonitor (RAM et Swap Monitor)

### DIFF
--- a/include/MemoryMonitor.h
+++ b/include/MemoryMonitor.h
@@ -1,0 +1,87 @@
+#ifndef MEMORY_MONITOR_H
+#define MEMORY_MONITOR_H
+
+#include <vector>
+#include <string>
+#include <fstream>
+#include <sstream>
+#include <iostream>
+
+using namespace std;
+
+class MemoryMonitor {
+private:
+    size_t totalMemMb;
+    float freeMem;
+    size_t SwapMemMb;
+    float freeSwap;
+
+    struct RAM {
+        vector<string> memInfo; // raw mem info li ja mn /proc/meminfo
+    } ram;
+
+public:
+    MemoryMonitor() : totalMemMb(0), freeMem(0), SwapMemMb(0), freeSwap(0) {}
+
+    // -------------------------------
+    // Méthode principale: update()
+    // -------------------------------
+    bool update() {
+        ifstream memFile("/proc/meminfo");
+        if (!memFile.is_open()) return false;
+
+        string line;
+        ram.memInfo.clear();
+
+        while (getline(memFile, line)) {
+            ram.memInfo.push_back(line);
+        }
+        memFile.close();
+
+        for (const auto& entry : ram.memInfo) {
+            istringstream iss(entry);
+            string key;
+            size_t value;
+            string unit;
+
+            iss >> key >> value >> unit;
+
+            if (key == "MemTotal:") totalMemMb = value / 1024;
+            else if (key == "MemFree:") freeMem = value / 1024.0;
+            else if (key == "SwapTotal:") SwapMemMb = value / 1024;
+            else if (key == "SwapFree:") freeSwap = value / 1024.0;
+        }
+
+        return true;
+    }
+
+    // -------------------------------
+    // Méthodes d'accès
+    // -------------------------------
+    unsigned long long getTotalMemory() const {
+        return totalMemMb;
+    }
+
+    unsigned long long getFreeMemory() const {
+        return static_cast<unsigned long long>(freeMem);
+    }
+
+    unsigned long long getTotalSwap() const {
+        return SwapMemMb;
+    }
+
+    unsigned long long getUsedSwap() const {
+        return static_cast<unsigned long long>(SwapMemMb - freeSwap);
+    }
+
+    double getMemoryUsagePercentage() const {
+        return ((totalMemMb - freeMem) / totalMemMb) * 100.0;
+    }
+
+    double getSwapUsagePercentage() const {
+        if (SwapMemMb == 0) return 0.0;
+        return ((SwapMemMb - freeSwap) / SwapMemMb) * 100.0;
+    }
+};
+
+#endif

--- a/include/SysMon.h
+++ b/include/SysMon.h
@@ -1,0 +1,13 @@
+#ifndef SYSMON_H
+#define SYSMON_H
+
+#include "CpuMonitor.cpp"
+#include "MemoryMonitor.cpp"
+#include "ProcessMonitor.cpp"
+
+class SysMon {
+public:
+    std::string exportAsJSON(CpuMonitor cpuMon, MemoryMonitor memMon, ProcessMonitor procMon);
+};
+
+#endif

--- a/src/MemoryMonitor.cpp
+++ b/src/MemoryMonitor.cpp
@@ -1,0 +1,46 @@
+#include <iostream>
+#include <fstream>
+#include <string>
+#include <sstream>
+
+class MemoryMonitor {
+public:
+    void afficherUtilisationMemoire();
+private:
+    long extraireValeur(const std::string& ligne);
+};
+
+long MemoryMonitor::extraireValeur(const std::string& ligne) {
+    std::istringstream iss(ligne);
+    std::string label;
+    long valeur;
+    std::string unite;
+    iss >> label >> valeur >> unite;
+    return valeur;
+}
+
+void MemoryMonitor::afficherUtilisationMemoire() {
+    std::ifstream meminfo("/proc/meminfo");
+    if (!meminfo) {
+        std::cerr << "Erreur lors de l'ouverture de /proc/meminfo" << std::endl;
+        return;
+    }
+
+    std::string ligne;
+    long total = 0, libre = 0;
+
+    while (std::getline(meminfo, ligne)) {
+        if (ligne.find("MemTotal:") == 0) {
+            total = extraireValeur(ligne);
+        } else if (ligne.find("MemAvailable:") == 0) {
+            libre = extraireValeur(ligne);
+            break;
+        }
+    }
+
+    long utilisee = total - libre;
+    std::cout << "Mémoire utilisée : " << utilisee / 1024 << " Mo / "
+              << total / 1024 << " Mo" << std::endl;
+    std::cout << "Mémoire libre : " << libre / 1024 << " Mo" << std::endl;
+}
+

--- a/src/SysMon.cpp
+++ b/src/SysMon.cpp
@@ -1,0 +1,33 @@
+#include "SysMon.h"
+#include <sstream>
+#include <iomanip>
+
+std::string SysMon::exportAsJSON(CpuMonitor cpuMon, MemoryMonitor memMon, ProcessMonitor procMon) {
+    std::ostringstream json;
+    json << "{\n";
+
+    json << "  \"cpu\": {\n";
+    json << "    \"usage\": " << std::fixed << std::setprecision(2) << cpuMon.getCpuUsage() << "\n";
+    json << "  },\n";
+
+    json << "  \"memory\": {\n";
+    json << "    \"used_percent\": " << memMon.getMemoryUsagePercentage() << "\n";
+    json << "  },\n";
+
+    json << "  \"processes\": [\n";
+    for (int i = 0; i < procMon.nbrProcess; ++i) {
+        auto p = procMon.getProcess(i);
+        json << "    {\n";
+        json << "      \"user\": \"" << p.user << "\",\n";
+        json << "      \"cpu\": " << p.cpu << ",\n";
+        json << "      \"memory\": " << p.memory << ",\n";
+        json << "      \"path\": \"" << p.pathName << "\"\n";
+        json << "    }";
+        if (i < procMon.nbrProcess - 1) json << ",";
+        json << "\n";
+    }
+    json << "  ]\n";
+    json << "}";
+
+    return json.str();
+}

--- a/src/disk_usage.cpp
+++ b/src/disk_usage.cpp
@@ -1,0 +1,22 @@
+#include <iostream>
+#include <sys/statvfs.h>
+
+void afficherUtilisationDisque(const std::string& chemin = "/") {
+    struct statvfs stats;
+
+    if (statvfs(chemin.c_str(), &stats) != 0) {
+        std::cerr << "Erreur lors de la récupération des informations du disque.\n";
+        return;
+    }
+
+    unsigned long taille_totale = stats.f_blocks * stats.f_frsize;
+    unsigned long taille_disponible = stats.f_bavail * stats.f_frsize;
+    unsigned long taille_utilisee = taille_totale - taille_disponible;
+    double pourcentage_utilisation = (double)taille_utilisee / taille_totale * 100;
+
+    std::cout << "=== Utilisation du disque pour: " << chemin << " ===\n";
+    std::cout << "Taille totale       : " << taille_totale / (1024 * 1024) << " MB\n";
+    std::cout << "Espace utilisé      : " << taille_utilisee / (1024 * 1024) << " MB\n";
+    std::cout << "Espace disponible   : " << taille_disponible / (1024 * 1024) << " MB\n";
+    std::cout << "Pourcentage utilisé : " << pourcentage_utilisation << " %\n";
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,25 @@
+#include "CpuMonitor.cpp"
+
+int main() {
+    CpuMonitor cpu;
+    cpu.showCpuUsage();
+    return 0;
+}
+#include "disk_usage.cpp"
+#include "SysMon.h"
+
+int main() {
+    CpuMonitor cpu;
+    MemoryMonitor mem;
+    ProcessMonitor proc;
+
+    cpu.update();
+    mem.update();
+    proc.update();
+
+    SysMon sys;
+    std::cout << sys.exportAsJSON(cpu, mem, proc) << std::endl;
+
+    return 0;
+}
+

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,4 +22,23 @@ int main() {
 
     return 0;
 }
+#include "MemoryMonitor.h"
+#include <iostream>
+
+int main() {
+    MemoryMonitor mem;
+    if (mem.update()) {
+        cout << "Total RAM: " << mem.getTotalMemory() << " MB" << endl;
+        cout << "Free RAM: " << mem.getFreeMemory() << " MB" << endl;
+        cout << "RAM Usage: " << mem.getMemoryUsagePercentage() << "%" << endl;
+
+        cout << "Total Swap: " << mem.getTotalSwap() << " MB" << endl;
+        cout << "Used Swap: " << mem.getUsedSwap() << " MB" << endl;
+        cout << "Swap Usage: " << mem.getSwapUsagePercentage() << "%" << endl;
+    } else {
+        cerr << "Failed to read memory info." << endl;
+    }
+    return 0;
+}
+
 


### PR DESCRIPTION
Cette PR ajoute une classe MemoryMonitor conforme à l'architecture du projet. Elle permet de lire les informations système (RAM et Swap) depuis /proc/meminfo, avec des méthodes claires : getTotalMemory(), getFreeMemory(), getSwapUsagePercentage() etc.
Elle inclut également un fichier main.cpp pour tester l'affichage